### PR TITLE
DT-5222: Fix favourite reordering on fav-service

### DIFF
--- a/dist/util/filterFavorites.js
+++ b/dist/util/filterFavorites.js
@@ -6,10 +6,11 @@ const filterFavorites = (favorites, type = undefined) => {
     const responseArray = keys.map((key) => {
         return Object(favorites)[key];
     });
+    const defaultTypes = ['route', 'stop', 'station', 'place', 'bikeStation'];
     const filteredArray = responseArray.filter(item => {
         const itemType = String(item.type);
         if (item &&
-            ((!types && !['note', 'postalCode'].includes(itemType)) ||
+            ((!types && defaultTypes.includes(itemType)) ||
                 (types && (types === null || types === void 0 ? void 0 : types.includes(itemType))))) {
             return true;
         }

--- a/dist/util/mergeFavorites.js
+++ b/dist/util/mergeFavorites.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const uuidv4_1 = require("uuidv4");
+const filterFavorites_1 = require("./filterFavorites");
 function mergeFavorites(currentFavorites, newFavorites, store) {
     const newData = {};
     const currentData = Object.values(currentFavorites).filter(elem => elem);
@@ -40,11 +41,22 @@ function mergeFavorites(currentFavorites, newFavorites, store) {
             newData[`${prefix}${newFavorite.favouriteId}`] = newFavorite;
         }
     });
+    const filteredNewKeys = Object.keys(filterFavorites_1.default(newData));
+    const filteredOldKeys = Object.keys(filterFavorites_1.default(currentFavorites));
     const newKeys = Object.keys(newData);
     const oldKeys = Object.keys(currentFavorites);
+    const reordered = {};
     // Reorder favorites
-    if (oldKeys.every(key => newKeys.includes(key))) {
-        return newData;
+    if (filteredOldKeys.every(key => filteredNewKeys.includes(key))) {
+        newKeys.forEach(key => {
+            reordered[key] = newData[key];
+        });
+        oldKeys.forEach(key => {
+            if (!Object.keys(reordered).includes(key)) {
+                reordered[key] = currentFavorites[key];
+            }
+        });
+        return reordered;
     }
     return Object.assign(currentFavorites, newData);
 }

--- a/dist/util/types.js
+++ b/dist/util/types.js
@@ -9,4 +9,5 @@ var FavouriteType;
     FavouriteType[FavouriteType["place"] = 3] = "place";
     FavouriteType[FavouriteType["bikeStation"] = 4] = "bikeStation";
     FavouriteType[FavouriteType["note"] = 5] = "note";
+    FavouriteType[FavouriteType["postalCode"] = 6] = "postalCode";
 })(FavouriteType = exports.FavouriteType || (exports.FavouriteType = {}));

--- a/util/filterFavorites.ts
+++ b/util/filterFavorites.ts
@@ -9,11 +9,12 @@ const filterFavorites = (
   const responseArray: Array<Favourite> = keys.map((key: string) => {
     return Object(favorites)[key];
   });
+  const defaultTypes = ['route', 'stop', 'station', 'place', 'bikeStation'];
   const filteredArray: Array<Favourite> = responseArray.filter(item => {
     const itemType = String(item.type);
     if (
       item &&
-      ((!types && !['note', 'postalCode'].includes(itemType)) ||
+      ((!types && defaultTypes.includes(itemType)) ||
         (types && types?.includes(itemType)))
     ) {
       return true;

--- a/util/mergeFavorites.ts
+++ b/util/mergeFavorites.ts
@@ -1,5 +1,6 @@
 import { uuid } from 'uuidv4';
 import { Favourite, Favourites } from './types';
+import filterFavorites from './filterFavorites';
 
 export default function mergeFavorites(
   currentFavorites: Favourites,
@@ -44,11 +45,22 @@ export default function mergeFavorites(
       newData[`${prefix}${newFavorite.favouriteId}`] = newFavorite;
     }
   });
+  const filteredNewKeys = Object.keys(filterFavorites(newData));
+  const filteredOldKeys = Object.keys(filterFavorites(currentFavorites));
   const newKeys = Object.keys(newData);
   const oldKeys = Object.keys(currentFavorites);
+  const reordered: Favourites = {};
   // Reorder favorites
-  if (oldKeys.every(key => newKeys.includes(key))) {
-    return newData;
+  if (filteredOldKeys.every(key => filteredNewKeys.includes(key))) {
+    newKeys.forEach(key => {
+      reordered[key] = newData[key];
+    });
+    oldKeys.forEach(key => {
+      if (!Object.keys(reordered).includes(key)) {
+        reordered[key] = currentFavorites[key];
+      }
+    });
+    return reordered;
   }
   return Object.assign(currentFavorites, newData);
 }

--- a/util/types.ts
+++ b/util/types.ts
@@ -7,6 +7,7 @@ export enum FavouriteType {
   'place',
   'bikeStation',
   'note',
+  'postalCode',
 }
 
 export interface Favourite {


### PR DESCRIPTION
- Fix favourite reordering when there are favourites saved with non default type (e.g. type postalCode or note)
- Add unit tests for reordering favourites.